### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/vveluguri/92b5625a-4fc5-4fe7-8d51-9cca08cc3c1b/31f9f833-219a-4067-9ab9-20cb1517aa2b/_apis/work/boardbadge/545e5bf6-8d3a-45dd-b0cf-99a609894a6c)](https://dev.azure.com/vveluguri/92b5625a-4fc5-4fe7-8d51-9cca08cc3c1b/_boards/board/t/31f9f833-219a-4067-9ab9-20cb1517aa2b/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vveluguri/92b5625a-4fc5-4fe7-8d51-9cca08cc3c1b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.